### PR TITLE
Fix SSL issue on php images

### DIFF
--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -5,8 +5,6 @@ LABEL maintainer="Julien Dufresne"
 RUN set -ex; \
         \
         buildDeps='\
-    		ca-certificates \
-	    	\
             libxml2-dev \
             zlib1g-dev \
         '; \

--- a/php/7.2/Dockerfile
+++ b/php/7.2/Dockerfile
@@ -5,8 +5,6 @@ LABEL maintainer="Julien Dufresne"
 RUN set -ex; \
         \
         buildDeps='\
-    		ca-certificates \
-	    	\
             libxml2-dev \
             zlib1g-dev \
         '; \


### PR DESCRIPTION
The build were removing apt ca-certificate package which is useful for
composer